### PR TITLE
Add chapter check-in and lobby screens

### DIFF
--- a/course-selection.html
+++ b/course-selection.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Course Selection · OC Quiz</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="teal-surface course-page">
+    <div class="course-page__inner">
+      <header class="course-header">
+        <h1>Course Selection</h1>
+        <nav aria-label="Session">
+          <a class="logout-link" href="index.html">Logout</a>
+        </nav>
+      </header>
+      <main class="course-selection" aria-labelledby="course-heading">
+        <h2 id="course-heading" class="visually-hidden">Available courses</h2>
+        <div class="course-list">
+          <a class="course-button" href="quiz-dashboard.html">Human Computer Interaction</a>
+          <a class="course-button" href="#">Lorem ipsum dolor sit amet consectetur</a>
+          <a class="course-button" href="#">Lorem ipsum dolor sit amet consectetur</a>
+        </div>
+      </main>
+    </div>
+    <script src="scripts/app.js" defer></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OC Quiz Login</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="teal-surface login-screen">
+    <header class="page-header">OC Login</header>
+    <main class="login-page">
+      <section class="hero-card" aria-label="Promotional artwork placeholder"></section>
+      <form id="login-form" class="login-form" novalidate>
+        <label class="input-wrapper">
+          <span class="visually-hidden">Username</span>
+          <input type="text" name="username" placeholder="Username" required />
+        </label>
+        <label class="input-wrapper">
+          <span class="visually-hidden">Password</span>
+          <input type="password" name="password" placeholder="Password" required />
+        </label>
+        <button type="submit">Sign in</button>
+      </form>
+    </main>
+    <script src="scripts/app.js" defer></script>
+  </body>
+</html>

--- a/quiz-builder.html
+++ b/quiz-builder.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Create Quiz · Question Builder</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="teal-surface builder-page">
+    <div class="builder-page__inner">
+      <nav class="page-nav" aria-label="Primary">
+        <a class="page-nav__link" href="quiz-dashboard.html">Return to Quizzes</a>
+        <a class="page-nav__link" href="index.html">Logout</a>
+      </nav>
+      <main class="builder-card" aria-labelledby="builder-heading">
+        <header class="builder-card__header">
+          <label class="builder-card__title-label visually-hidden" for="quiz-title">Enter quiz title...</label>
+          <input
+            class="builder-card__title-input"
+            type="text"
+            id="quiz-title"
+            name="quiz-title"
+            placeholder="Enter quiz title..."
+            value="Human Computer Interaction"
+          />
+        </header>
+        <form class="question-form" aria-labelledby="builder-heading">
+          <h1 id="builder-heading" class="visually-hidden">Quiz Question Builder</h1>
+          <div class="question-grid">
+            <section class="question-panel" aria-labelledby="question-type-label">
+              <h2 id="question-type-label" class="panel-title">Question Type</h2>
+              <div role="group" aria-labelledby="question-type-label" class="chip-toggle-group">
+                <button type="button" class="chip-toggle is-active">Multiple Choice</button>
+                <button type="button" class="chip-toggle">True / False</button>
+              </div>
+              <div class="panel-divider" role="presentation"></div>
+              <h2 class="panel-title" id="correct-answer-label">Correct Answer(s)</h2>
+              <ul class="answer-checklist" aria-labelledby="correct-answer-label">
+                <li>
+                  <label class="checkbox-pill">
+                    <input type="checkbox" name="correct-choice" checked />
+                    <span class="checkbox-pill__visual"></span>
+                    <span class="checkbox-pill__label">Lorem ipsum dolor</span>
+                  </label>
+                </li>
+                <li>
+                  <label class="checkbox-pill">
+                    <input type="checkbox" name="correct-choice" />
+                    <span class="checkbox-pill__visual"></span>
+                    <span class="checkbox-pill__label">Lorem ipsum dolor</span>
+                  </label>
+                </li>
+                <li>
+                  <label class="checkbox-pill">
+                    <input type="checkbox" name="correct-choice" />
+                    <span class="checkbox-pill__visual"></span>
+                    <span class="checkbox-pill__label">Lorem ipsum dolor</span>
+                  </label>
+                </li>
+                <li>
+                  <label class="checkbox-pill">
+                    <input type="checkbox" name="correct-choice" />
+                    <span class="checkbox-pill__visual"></span>
+                    <span class="checkbox-pill__label">Lorem ipsum dolor</span>
+                  </label>
+                </li>
+              </ul>
+            </section>
+            <section class="question-panel question-panel--content" aria-labelledby="question-content-label">
+              <h2 id="question-content-label" class="panel-title">Enter question...</h2>
+              <textarea
+                class="question-textarea"
+                name="question"
+                rows="3"
+                placeholder="Enter question...">Lorem ipsum dolor sit amet consectetur?</textarea>
+              <div class="panel-divider" role="presentation"></div>
+              <h2 class="panel-title" id="answer-choices-label">Answer Choices</h2>
+              <ul class="choice-list" aria-labelledby="answer-choices-label">
+                <li class="choice-item">
+                  <span class="choice-bullet" aria-hidden="true">A</span>
+                  <input
+                    type="text"
+                    class="choice-input"
+                    value="Lorem ipsum dolor sit amet consectetur"
+                    aria-label="Answer choice A"
+                  />
+                  <button type="button" class="choice-action" aria-label="Edit choice A">
+                    <span aria-hidden="true" class="icon-pencil"></span>
+                  </button>
+                </li>
+                <li class="choice-item">
+                  <span class="choice-bullet" aria-hidden="true">B</span>
+                  <input
+                    type="text"
+                    class="choice-input"
+                    value="Lorem ipsum dolor sit amet consectetur"
+                    aria-label="Answer choice B"
+                  />
+                  <button type="button" class="choice-action" aria-label="Edit choice B">
+                    <span aria-hidden="true" class="icon-pencil"></span>
+                  </button>
+                </li>
+                <li class="choice-item">
+                  <span class="choice-bullet" aria-hidden="true">C</span>
+                  <input
+                    type="text"
+                    class="choice-input"
+                    value="Lorem ipsum dolor sit amet consectetur"
+                    aria-label="Answer choice C"
+                  />
+                  <button type="button" class="choice-action" aria-label="Edit choice C">
+                    <span aria-hidden="true" class="icon-pencil"></span>
+                  </button>
+                </li>
+                <li class="choice-item">
+                  <span class="choice-bullet" aria-hidden="true">D</span>
+                  <input
+                    type="text"
+                    class="choice-input"
+                    value="Lorem ipsum dolor sit amet consectetur"
+                    aria-label="Answer choice D"
+                  />
+                  <button type="button" class="choice-action" aria-label="Edit choice D">
+                    <span aria-hidden="true" class="icon-pencil"></span>
+                  </button>
+                </li>
+              </ul>
+              <button type="button" class="add-choice-button">Add answer choice</button>
+            </section>
+          </div>
+          <footer class="builder-footer">
+            <div class="builder-footer__group">
+              <label class="footer-field" for="time-allowed">
+                <span class="footer-field__label">Time allowed:</span>
+                <select id="time-allowed" class="footer-select">
+                  <option>30s</option>
+                  <option>45s</option>
+                  <option selected>60s</option>
+                  <option>90s</option>
+                </select>
+              </label>
+              <label class="footer-toggle">
+                <input type="checkbox" checked />
+                <span class="footer-toggle__visual" aria-hidden="true"></span>
+                <span class="footer-toggle__label">Lock Question Upon Submitting</span>
+              </label>
+              <label class="footer-toggle">
+                <input type="checkbox" />
+                <span class="footer-toggle__visual" aria-hidden="true"></span>
+                <span class="footer-toggle__label">Enable Quiz Review</span>
+              </label>
+            </div>
+            <button type="submit" class="primary-button primary-button--save">Save</button>
+          </footer>
+        </form>
+      </main>
+    </div>
+  </body>
+</html>

--- a/quiz-chapter-lobby.html
+++ b/quiz-chapter-lobby.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chapter 1 · Quiz Lobby</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="teal-surface chapter-stage">
+    <div class="chapter-stage__container">
+      <header class="chapter-stage__header" aria-label="Chapter navigation">
+        <div class="chapter-stage__heading">Chapter 1</div>
+        <nav class="chapter-stage__nav" aria-label="Secondary">
+          <a class="chapter-stage__link" href="quiz-dashboard.html">Return to Quizzes</a>
+          <a class="chapter-stage__link" href="index.html">Logout</a>
+        </nav>
+      </header>
+      <main class="stage-card stage-card--center" aria-labelledby="lobby-title">
+        <div class="stage-card__panel">
+          <h1 id="lobby-title" class="visually-hidden">Students Joined</h1>
+          <ul class="lobby-list" aria-live="polite">
+            <li>Student 1 has joined...</li>
+            <li>Student 2 has joined...</li>
+            <li>Student 3 has joined...</li>
+            <li>Student 4 has joined...</li>
+            <li>Student 5 has joined...</li>
+            <li>Student 6 has joined...</li>
+            <li>Student 7 has joined...</li>
+            <li>Student 8 has joined...</li>
+            <li>Student 9 has joined...</li>
+          </ul>
+          <button class="stage-card__cta" type="button" data-target="quiz-builder.html">
+            Start Quiz
+          </button>
+        </div>
+      </main>
+    </div>
+    <script src="scripts/app.js" defer></script>
+  </body>
+</html>

--- a/quiz-chapter-qr.html
+++ b/quiz-chapter-qr.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chapter 1 · Quiz Check-In</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="teal-surface chapter-stage">
+    <div class="chapter-stage__container">
+      <header class="chapter-stage__header" aria-label="Chapter navigation">
+        <div class="chapter-stage__heading">Chapter 1</div>
+        <nav class="chapter-stage__nav" aria-label="Secondary">
+          <a class="chapter-stage__link" href="quiz-dashboard.html">Return to Quizzes</a>
+          <a class="chapter-stage__link" href="index.html">Logout</a>
+        </nav>
+      </header>
+      <main class="stage-card stage-card--center" aria-labelledby="qr-title">
+        <div class="stage-card__panel">
+          <h1 id="qr-title" class="visually-hidden">Scan to Join Chapter 1</h1>
+          <div class="qr-display" role="img" aria-label="QR code placeholder">
+            <span class="qr-display__cell qr-display__cell--solid"></span>
+            <span class="qr-display__cell qr-display__cell--solid"></span>
+            <span class="qr-display__cell qr-display__cell--clear"></span>
+            <span class="qr-display__cell qr-display__cell--solid"></span>
+            <span class="qr-display__cell qr-display__cell--clear"></span>
+            <span class="qr-display__cell qr-display__cell--clear"></span>
+            <span class="qr-display__cell qr-display__cell--clear"></span>
+            <span class="qr-display__cell qr-display__cell--mini">
+              <span></span>
+              <span></span>
+              <span class="qr-display__dot qr-display__dot--clear"></span>
+              <span></span>
+            </span>
+            <span class="qr-display__cell qr-display__cell--clear"></span>
+          </div>
+          <button class="stage-card__cta" type="button" data-target="quiz-chapter-lobby.html">
+            Next
+          </button>
+        </div>
+      </main>
+    </div>
+    <script src="scripts/app.js" defer></script>
+  </body>
+</html>

--- a/quiz-dashboard.html
+++ b/quiz-dashboard.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Human Computer Interaction · Quiz Overview</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="teal-surface results-page">
+    <div class="results-page__inner">
+      <nav class="page-nav" aria-label="Primary">
+        <a class="page-nav__link" href="course-selection.html">Return to Courses</a>
+        <a class="page-nav__link" href="index.html">Logout</a>
+      </nav>
+      <main class="results-card" aria-labelledby="course-title">
+        <header class="results-card__header">
+          <h1 id="course-title">Human Computer Interaction</h1>
+        </header>
+        <section class="chapter-section" aria-labelledby="chapter-1">
+          <div class="chapter-section__heading">
+            <h2 id="chapter-1">Chapter 1</h2>
+            <button class="download-button" type="button">
+              Download Results
+              <span class="download-button__icon" aria-hidden="true"></span>
+            </button>
+          </div>
+          <div class="results-table" role="table" aria-label="Chapter 1 quiz results">
+            <div class="results-table__header" role="row">
+              <span class="column-title" role="columnheader">Student Name</span>
+              <span class="column-title" role="columnheader">Quiz Taken</span>
+              <span class="column-title" role="columnheader">Total Correct</span>
+              <span class="column-title" role="columnheader">View Answers</span>
+            </div>
+            <div class="results-table__row" role="row">
+              <span class="student" role="cell">Joe Smith</span>
+              <span class="status" role="cell">
+                <span class="status-indicator status-indicator--complete" aria-hidden="true"></span>
+                <span class="status-text">10 / 10</span>
+              </span>
+              <span class="score" role="cell">10 / 10</span>
+              <span class="action" role="cell"><button class="link-button" type="button">See Results</button></span>
+            </div>
+            <div class="results-table__row" role="row">
+              <span class="student" role="cell">Kevin Smith</span>
+              <span class="status" role="cell">
+                <span class="status-indicator status-indicator--complete" aria-hidden="true"></span>
+                <span class="status-text">8 / 10</span>
+              </span>
+              <span class="score" role="cell">8 / 10</span>
+              <span class="action" role="cell"><button class="link-button" type="button">See Results</button></span>
+            </div>
+            <div class="results-table__row" role="row">
+              <span class="student" role="cell">Maggie Smith</span>
+              <span class="status" role="cell">
+                <span class="status-indicator status-indicator--complete" aria-hidden="true"></span>
+                <span class="status-text">6 / 10</span>
+              </span>
+              <span class="score" role="cell">6 / 10</span>
+              <span class="action" role="cell"><button class="link-button" type="button">See Results</button></span>
+            </div>
+            <div class="results-table__row" role="row">
+              <span class="student" role="cell">Wayne Smith</span>
+              <span class="status" role="cell">
+                <span class="status-indicator status-indicator--missing" aria-hidden="true"></span>
+                <span class="status-text">4 / 10</span>
+              </span>
+              <span class="score" role="cell">4 / 10</span>
+              <span class="action" role="cell"><button class="link-button" type="button">See Results</button></span>
+            </div>
+            <div class="results-table__row" role="row">
+              <span class="student" role="cell">Dedra Smith</span>
+              <span class="status" role="cell">
+                <span class="status-indicator status-indicator--pending" aria-hidden="true"></span>
+                <span class="status-text">—</span>
+              </span>
+              <span class="score" role="cell">—</span>
+              <span class="action" role="cell"><button class="link-button link-button--accent" type="button" data-target="quiz-chapter-qr.html">Start Quiz</button></span>
+            </div>
+          </div>
+        </section>
+        <section class="chapter-summary" aria-labelledby="chapter-2">
+          <h2 id="chapter-2">Chapter 2</h2>
+          <div class="chapter-summary__actions">
+            <button class="pill-button pill-button--accent" type="button" data-target="quiz-chapter-qr.html">Start Quiz</button>
+            <button class="pill-button pill-button--muted" type="button" disabled>Results Unavailable</button>
+          </div>
+        </section>
+        <section class="chapter-summary" aria-labelledby="chapter-3">
+          <h2 id="chapter-3">Chapter 3</h2>
+          <div class="chapter-summary__actions">
+            <button class="pill-button pill-button--accent" type="button" data-target="quiz-chapter-qr.html">Start Quiz</button>
+            <button class="pill-button pill-button--cool" type="button">See Results</button>
+          </div>
+        </section>
+        <div class="card-footer">
+          <button class="primary-button" type="button" id="create-quiz-button">Create New Quiz</button>
+        </div>
+      </main>
+    </div>
+    <script src="scripts/app.js" defer></script>
+  </body>
+</html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const loginForm = document.getElementById('login-form');
+
+  if (loginForm) {
+    loginForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const username = loginForm.elements.namedItem('username');
+      const password = loginForm.elements.namedItem('password');
+
+      username?.setAttribute('aria-invalid', !username.value ? 'true' : 'false');
+      password?.setAttribute('aria-invalid', !password.value ? 'true' : 'false');
+
+      if (username?.value && password?.value) {
+        window.location.href = 'course-selection.html';
+      }
+    });
+  }
+
+  const createQuizButton = document.getElementById('create-quiz-button');
+  if (createQuizButton) {
+    createQuizButton.addEventListener('click', () => {
+      window.location.href = 'quiz-builder.html';
+    });
+  }
+
+  const chipToggles = document.querySelectorAll('.chip-toggle');
+  if (chipToggles.length) {
+    chipToggles.forEach((toggle) => {
+      toggle.addEventListener('click', () => {
+        chipToggles.forEach((btn) => btn.classList.remove('is-active'));
+        toggle.classList.add('is-active');
+      });
+    });
+  }
+
+  const navigationTriggers = document.querySelectorAll('[data-target]');
+  if (navigationTriggers.length) {
+    navigationTriggers.forEach((trigger) => {
+      trigger.addEventListener('click', () => {
+        const target = trigger.getAttribute('data-target');
+        if (target) {
+          window.location.href = target;
+        }
+      });
+    });
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1351 @@
+:root {
+  color-scheme: light dark;
+  --teal-dark: #0b4d5a;
+  --teal-muted: #0f5d6c;
+  --teal-soft: #137384;
+  --card-shadow: rgba(0, 0, 0, 0.25);
+  --input-bg: #f1f2f3;
+  --input-text: #4c4c4c;
+  --pill-highlight: #2cb6c9;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  display: flex;
+  justify-content: center;
+}
+
+body.teal-surface {
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.08), transparent 60%),
+    radial-gradient(circle at bottom right, rgba(255, 255, 255, 0.12), transparent 70%),
+    var(--teal-dark);
+  color: #fff;
+  position: relative;
+  overflow: hidden;
+}
+
+body.teal-surface::before,
+body.teal-surface::after {
+  content: '';
+  position: fixed;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  z-index: -1;
+}
+
+body.teal-surface::before {
+  width: 360px;
+  height: 360px;
+  bottom: -120px;
+  right: -80px;
+}
+
+body.teal-surface::after {
+  width: 220px;
+  height: 220px;
+  bottom: 120px;
+  left: 80px;
+}
+
+body.login-screen {
+  flex-direction: column;
+  align-items: center;
+}
+
+.page-header {
+  width: 100%;
+  max-width: 900px;
+  padding: 24px 40px 0;
+  font-size: 18px;
+  letter-spacing: 0.08em;
+}
+
+.login-page {
+  width: 100%;
+  max-width: 900px;
+  padding: 24px 40px 80px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 48px;
+}
+
+.hero-card {
+  width: 100%;
+  max-width: 800px;
+  aspect-ratio: 2.4 / 1;
+  background: #fff;
+  position: relative;
+  border: 2px solid #d8e5ea;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
+}
+
+.hero-card::before,
+.hero-card::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 110%;
+  border-top: 2px solid #5a5a5a;
+}
+
+.hero-card::before {
+  transform: translate(-50%, -50%) rotate(27deg);
+}
+
+.hero-card::after {
+  transform: translate(-50%, -50%) rotate(-27deg);
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  width: min(360px, 80%);
+}
+
+.input-wrapper {
+  width: 100%;
+}
+
+.input-wrapper input {
+  width: 100%;
+  border: none;
+  border-radius: 10px;
+  padding: 14px 18px;
+  font-size: 16px;
+  background: var(--input-bg);
+  color: var(--input-text);
+  text-align: center;
+  outline: 2px solid transparent;
+  transition: outline-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input-wrapper input:focus {
+  outline-color: #9fd0d8;
+  box-shadow: 0 0 0 4px rgba(159, 208, 216, 0.25);
+}
+
+.login-form button {
+  border: none;
+  border-radius: 10px;
+  padding: 14px 24px;
+  width: 160px;
+  font-size: 16px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--teal-dark);
+  cursor: pointer;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-form button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
+}
+
+.login-form button:active {
+  transform: translateY(0);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+body.course-page {
+  width: 100%;
+  align-items: stretch;
+}
+
+body.results-page {
+  width: 100%;
+  align-items: center;
+  padding: clamp(40px, 8vw, 72px) clamp(16px, 6vw, 48px) clamp(60px, 10vw, 96px);
+  color: #1e3f4c;
+}
+
+.results-page__inner {
+  width: min(1040px, 100%);
+}
+
+.page-nav {
+  display: flex;
+  justify-content: flex-end;
+  gap: clamp(12px, 3vw, 24px);
+  margin-bottom: clamp(24px, 4vw, 32px);
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.page-nav__link {
+  color: #f5f7f8;
+  text-decoration: none;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.22);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.22);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.page-nav__link:hover,
+.page-nav__link:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.32);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.26);
+}
+
+.page-nav__link:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 3px;
+}
+
+.course-page__inner {
+  width: min(960px, 100%);
+  margin: 0 auto;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.results-card {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(236, 244, 248, 0.95));
+  border-radius: 22px;
+  box-shadow: 0 28px 48px rgba(5, 32, 40, 0.38);
+  border: 2px solid rgba(255, 255, 255, 0.45);
+  overflow: hidden;
+}
+
+.results-card__header {
+  background: linear-gradient(135deg, rgba(19, 115, 132, 0.92), rgba(44, 182, 201, 0.88));
+  padding: clamp(20px, 4vw, 32px);
+  text-align: center;
+  color: #f8fcff;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.results-card__header h1 {
+  margin: 0;
+  font-size: clamp(20px, 2.6vw, 26px);
+  font-weight: 600;
+}
+
+.chapter-section,
+.chapter-summary {
+  padding: clamp(20px, 4vw, 28px) clamp(18px, 5vw, 32px);
+  border-bottom: 1px solid rgba(12, 70, 83, 0.12);
+}
+
+.chapter-section:last-of-type,
+.chapter-summary:last-of-type {
+  border-bottom: none;
+}
+
+.chapter-section__heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.chapter-section__heading h2,
+.chapter-summary h2 {
+  margin: 0;
+  font-size: clamp(18px, 2.4vw, 22px);
+  font-weight: 600;
+  color: #155062;
+}
+
+.download-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid rgba(19, 115, 132, 0.4);
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(226, 243, 247, 0.9));
+  color: #155062;
+  font-weight: 600;
+  padding: 10px 20px;
+  cursor: pointer;
+  box-shadow: inset 0 2px 4px rgba(255, 255, 255, 0.5), 0 8px 16px rgba(5, 32, 40, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.download-button:hover {
+  transform: translateY(-2px);
+  box-shadow: inset 0 2px 4px rgba(255, 255, 255, 0.5), 0 12px 26px rgba(5, 32, 40, 0.22);
+}
+
+.download-button__icon {
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  border: 1px solid rgba(19, 115, 132, 0.4);
+  background:
+    linear-gradient(180deg, rgba(58, 169, 187, 0.95), rgba(20, 97, 111, 0.95)),
+    linear-gradient(180deg, transparent 45%, rgba(255, 255, 255, 0.7) 45%, rgba(255, 255, 255, 0.7) 55%, transparent 55%);
+  display: inline-block;
+  position: relative;
+}
+
+.download-button__icon::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 6px;
+  height: 8px;
+  border: 2px solid #f4fbff;
+  border-top: none;
+  border-left: none;
+  transform: translate(-50%, -45%) rotate(45deg);
+}
+
+.results-table {
+  border-radius: 18px;
+  border: 1px solid rgba(33, 91, 108, 0.2);
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  width: 100%;
+}
+
+.results-table__header,
+.results-table__row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1.4fr) minmax(150px, 1fr) minmax(140px, 1fr) minmax(140px, 1fr);
+  align-items: center;
+  padding: clamp(12px, 2vw, 18px) clamp(18px, 3vw, 32px);
+  gap: 18px;
+}
+
+.results-table__header {
+  background: linear-gradient(180deg, rgba(19, 115, 132, 0.16), rgba(19, 115, 132, 0));
+  font-size: 14px;
+  font-weight: 700;
+  color: #0f5364;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.results-table__row:nth-of-type(odd) {
+  background: rgba(238, 245, 249, 0.8);
+}
+
+.results-table__row:nth-of-type(even) {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.results-table__row:last-of-type {
+  border-bottom: none;
+}
+
+.results-table__row .student {
+  font-weight: 600;
+  color: #123b4a;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  color: #155062;
+}
+
+.status-indicator {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  display: inline-block;
+  position: relative;
+}
+
+.status-indicator::before,
+.status-indicator::after {
+  content: '';
+  position: absolute;
+}
+
+.status-indicator--complete {
+  color: #0f905d;
+  background: rgba(15, 144, 93, 0.12);
+}
+
+.status-indicator--complete::after {
+  width: 6px;
+  height: 12px;
+  border: 3px solid currentColor;
+  border-top: 0;
+  border-left: 0;
+  left: 50%;
+  top: 48%;
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.status-indicator--missing {
+  color: #ce2f2f;
+  background: rgba(206, 47, 47, 0.12);
+}
+
+.status-indicator--missing::before,
+.status-indicator--missing::after {
+  width: 12px;
+  height: 2px;
+  background: currentColor;
+  left: 50%;
+  top: 50%;
+  border-radius: 2px;
+}
+
+.status-indicator--missing::before {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.status-indicator--missing::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+.status-indicator--pending {
+  color: #c7a13b;
+  background: rgba(199, 161, 59, 0.12);
+}
+
+.status-indicator--pending::after {
+  width: 8px;
+  height: 8px;
+  border-radius: 1px;
+  border: 2px solid currentColor;
+  border-top: none;
+  transform: translate(-50%, -30%);
+  left: 50%;
+  top: 35%;
+}
+
+.status-text {
+  font-variant-numeric: tabular-nums;
+}
+
+.score {
+  font-weight: 600;
+  color: #0c495a;
+  font-variant-numeric: tabular-nums;
+}
+
+.action {
+  text-align: right;
+}
+
+.link-button {
+  border: 1px solid rgba(19, 115, 132, 0.6);
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(217, 236, 241, 0.9));
+  color: #0f5d6c;
+  font-weight: 600;
+  padding: 8px 18px;
+  cursor: pointer;
+  box-shadow: 0 8px 16px rgba(15, 93, 108, 0.16);
+  text-transform: capitalize;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.link-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(15, 93, 108, 0.2);
+}
+
+.link-button--accent {
+  background: linear-gradient(135deg, #f7c15e, #f29b22);
+  border-color: rgba(215, 126, 17, 0.65);
+  color: #663702;
+  box-shadow: 0 10px 20px rgba(215, 126, 17, 0.24);
+}
+
+.link-button--accent:hover {
+  box-shadow: 0 14px 26px rgba(215, 126, 17, 0.3);
+}
+
+.chapter-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.chapter-summary__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.pill-button {
+  border: 1px solid rgba(15, 93, 108, 0.4);
+  border-radius: 24px;
+  padding: 10px 22px;
+  background: rgba(255, 255, 255, 0.85);
+  color: #0f5d6c;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 8px 16px rgba(13, 74, 86, 0.16);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.pill-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 22px rgba(13, 74, 86, 0.22);
+}
+
+.pill-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  background: rgba(229, 235, 238, 0.9);
+  border-color: rgba(12, 70, 83, 0.12);
+  color: rgba(12, 70, 83, 0.55);
+  box-shadow: none;
+}
+
+.pill-button--accent {
+  background: linear-gradient(135deg, #f7c15e, #f29b22);
+  border-color: rgba(215, 126, 17, 0.65);
+  color: #6a3b00;
+}
+
+.pill-button--accent:hover {
+  box-shadow: 0 12px 24px rgba(215, 126, 17, 0.24);
+}
+
+.pill-button--muted {
+  background: linear-gradient(135deg, rgba(214, 224, 229, 0.9), rgba(203, 214, 219, 0.9));
+  color: #4b646f;
+}
+
+.pill-button--cool {
+  background: linear-gradient(135deg, rgba(37, 146, 167, 0.92), rgba(53, 181, 204, 0.92));
+  border-color: rgba(19, 115, 132, 0.45);
+  color: #f3fdff;
+}
+
+.pill-button--cool:hover {
+  box-shadow: 0 12px 24px rgba(12, 90, 106, 0.28);
+}
+
+.card-footer {
+  padding: clamp(24px, 5vw, 36px);
+  display: flex;
+  justify-content: center;
+  background: linear-gradient(180deg, rgba(229, 240, 245, 0.8), rgba(202, 222, 231, 0.8));
+}
+
+.primary-button {
+  border: none;
+  border-radius: 999px;
+  padding: 16px clamp(40px, 12vw, 160px);
+  font-size: clamp(16px, 2vw, 18px);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  background: linear-gradient(135deg, #0f5d6c, #2cb6c9);
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 16px 28px rgba(11, 77, 90, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 34px rgba(11, 77, 90, 0.36);
+}
+
+.primary-button:focus-visible {
+  outline: 4px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 4px;
+}
+
+@media (max-width: 720px) {
+  body.results-page {
+    padding: 32px 16px 64px;
+  }
+
+  .results-table__header {
+    display: none;
+  }
+
+  .results-table__row {
+    grid-template-columns: 1fr;
+    justify-items: flex-start;
+    gap: 6px;
+    padding: 14px 18px;
+  }
+
+  .results-table__row .student {
+    font-size: 16px;
+  }
+
+  .status,
+  .score,
+  .action {
+    width: 100%;
+  }
+
+  .action {
+    text-align: left;
+  }
+
+  .page-nav {
+    justify-content: center;
+  }
+}
+
+.course-header {
+  background: rgba(243, 244, 245, 0.95);
+  color: var(--teal-dark);
+  padding: 28px clamp(24px, 5vw, 48px) 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  border-bottom-left-radius: 18px;
+  border-bottom-right-radius: 18px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: clamp(16px, 2vw, 18px);
+}
+
+.course-header h1 {
+  margin: 0;
+  font-size: inherit;
+}
+
+.logout-link {
+  color: var(--teal-soft);
+  font-weight: 600;
+  text-decoration: none;
+  padding: 12px 20px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.6);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.logout-link:hover,
+.logout-link:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.24);
+}
+
+.logout-link:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.course-selection {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(40px, 10vw, 96px);
+}
+
+.course-list {
+  width: min(520px, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 6vw, 32px);
+}
+
+.course-button {
+  display: block;
+  text-align: center;
+  padding: clamp(18px, 4vw, 24px);
+  border-radius: 24px;
+  background: linear-gradient(135deg, var(--teal-soft), var(--pill-highlight));
+  color: #fff;
+  font-size: clamp(16px, 2.6vw, 20px);
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.28);
+  letter-spacing: 0.02em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.course-button:hover,
+.course-button:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.32);
+}
+
+.course-button:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 3px;
+}
+
+@media (max-width: 768px) {
+  .login-page {
+    padding: 24px;
+    gap: 36px;
+  }
+
+  .hero-card {
+    max-width: 100%;
+  }
+
+  .course-header {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+
+  .course-header nav {
+    display: flex;
+    justify-content: center;
+  }
+}
+
+/* Quiz builder layout */
+body.builder-page {
+  width: 100%;
+  align-items: center;
+  padding: clamp(40px, 7vw, 80px) clamp(16px, 5vw, 56px) clamp(64px, 10vw, 100px);
+  color: #12323d;
+}
+
+.builder-page__inner {
+  width: min(1100px, 100%);
+}
+
+.builder-card {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(255, 255, 255, 0.9));
+  border-radius: 24px;
+  padding: clamp(28px, 5vw, 40px);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(6px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 4vw, 32px);
+}
+
+.builder-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.builder-card__title-label {
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4a7c86;
+}
+
+.builder-card__title-input {
+  width: 100%;
+  border-radius: 16px;
+  border: 1px solid rgba(18, 50, 61, 0.2);
+  background: rgba(255, 255, 255, 0.92);
+  padding: 16px 22px;
+  font-size: clamp(20px, 2.6vw, 28px);
+  font-weight: 600;
+  color: #0f404d;
+  box-shadow: inset 0 2px 6px rgba(12, 48, 56, 0.08);
+}
+
+.builder-card__title-input::placeholder {
+  color: rgba(18, 50, 61, 0.45);
+}
+
+.question-form {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(32px, 4vw, 48px);
+}
+
+.question-grid {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) minmax(360px, 2fr);
+  gap: clamp(24px, 4vw, 40px);
+}
+
+.question-panel {
+  background: rgba(241, 245, 246, 0.95);
+  border-radius: 18px;
+  padding: clamp(20px, 3vw, 28px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), 0 18px 40px rgba(10, 40, 48, 0.12);
+  border: 1px solid rgba(12, 48, 56, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3vw, 24px);
+}
+
+.panel-title {
+  font-size: clamp(16px, 2vw, 20px);
+  font-weight: 600;
+  margin: 0;
+  color: #134754;
+}
+
+.chip-toggle-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.chip-toggle {
+  border: 1px solid rgba(19, 71, 84, 0.2);
+  border-radius: 999px;
+  padding: 10px 22px;
+  background: rgba(255, 255, 255, 0.86);
+  font-size: 14px;
+  font-weight: 600;
+  color: #225b69;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chip-toggle.is-active {
+  background: linear-gradient(135deg, #2cb6c9, #1d8a9c);
+  color: #fff;
+  box-shadow: 0 8px 18px rgba(32, 132, 150, 0.35);
+}
+
+.panel-divider {
+  width: 100%;
+  height: 1px;
+  background: rgba(12, 48, 56, 0.12);
+}
+
+.answer-checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.checkbox-pill {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.86);
+  border-radius: 999px;
+  padding: 8px 16px;
+  border: 1px solid rgba(19, 71, 84, 0.16);
+  cursor: pointer;
+  font-size: 14px;
+  color: #2b5d68;
+}
+
+.checkbox-pill input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.checkbox-pill__visual {
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  border: 2px solid rgba(31, 104, 120, 0.4);
+  background: #fff;
+  position: relative;
+}
+
+.checkbox-pill__visual::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6px;
+  height: 10px;
+  border: 2px solid transparent;
+  border-left-color: #fff;
+  border-bottom-color: #fff;
+  transform: translate(-50%, -60%) rotate(-45deg) scale(0);
+  transform-origin: center;
+  transition: transform 0.18s ease;
+}
+
+.checkbox-pill input:checked + .checkbox-pill__visual {
+  background: #1d8a9c;
+  border-color: #1d8a9c;
+}
+
+.checkbox-pill input:checked + .checkbox-pill__visual::after {
+  transform: translate(-50%, -60%) rotate(-45deg) scale(1);
+}
+
+.checkbox-pill__label {
+  font-weight: 600;
+}
+
+.question-panel--content {
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.question-textarea {
+  width: 100%;
+  min-height: 120px;
+  border-radius: 14px;
+  border: 1px solid rgba(16, 64, 77, 0.18);
+  padding: 16px 18px;
+  font-size: 16px;
+  resize: vertical;
+  color: #1c4753;
+  background: rgba(244, 248, 249, 0.9);
+}
+
+.choice-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.choice-item {
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: rgba(236, 245, 247, 0.95);
+  border: 1px solid rgba(17, 73, 86, 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.choice-bullet {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #1c4753;
+  background: rgba(44, 182, 201, 0.3);
+}
+
+.choice-input {
+  border: none;
+  background: transparent;
+  font-size: 15px;
+  color: #1c4753;
+  font-weight: 600;
+}
+
+.choice-input:focus {
+  outline: 2px solid rgba(32, 132, 150, 0.4);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.choice-action {
+  border: none;
+  background: transparent;
+  color: #1d8a9c;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.choice-action:hover {
+  background: rgba(29, 138, 156, 0.12);
+}
+
+.icon-pencil {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  display: inline-block;
+}
+
+.icon-pencil::before,
+.icon-pencil::after {
+  content: '';
+  position: absolute;
+  border-radius: 2px;
+}
+
+.icon-pencil::before {
+  width: 14px;
+  height: 4px;
+  background: #1d8a9c;
+  transform: rotate(45deg);
+  top: 4px;
+  left: 0;
+}
+
+.icon-pencil::after {
+  width: 4px;
+  height: 4px;
+  background: #0f404d;
+  transform: rotate(45deg);
+  bottom: -1px;
+  right: -2px;
+}
+
+.add-choice-button {
+  align-self: flex-start;
+  border: 1px dashed rgba(29, 138, 156, 0.5);
+  border-radius: 999px;
+  padding: 10px 22px;
+  font-size: 14px;
+  font-weight: 600;
+  background: transparent;
+  color: #1d8a9c;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.add-choice-button:hover {
+  background: rgba(29, 138, 156, 0.08);
+  border-color: rgba(29, 138, 156, 0.8);
+}
+
+.builder-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: clamp(16px, 3vw, 24px);
+  flex-wrap: wrap;
+}
+
+.builder-footer__group {
+  display: flex;
+  align-items: center;
+  gap: clamp(16px, 3vw, 24px);
+  flex-wrap: wrap;
+}
+
+.footer-field {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  letter-spacing: 0.02em;
+  color: #1c4753;
+}
+
+.footer-field__label {
+  font-weight: 600;
+}
+
+.footer-select {
+  border-radius: 999px;
+  border: 1px solid rgba(18, 71, 84, 0.25);
+  padding: 8px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.9);
+  color: #1c4753;
+}
+
+.footer-toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #1c4753;
+  cursor: pointer;
+}
+
+.footer-toggle input {
+  appearance: none;
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(29, 138, 156, 0.4);
+  position: relative;
+  transition: background 0.2s ease;
+}
+
+.footer-toggle input::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 3px;
+  transform: translate(0, -50%);
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(29, 138, 156, 0.5);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.footer-toggle input:checked {
+  background: rgba(29, 138, 156, 0.3);
+}
+
+.footer-toggle input:checked::after {
+  transform: translate(18px, -50%);
+  background: #1d8a9c;
+}
+
+.primary-button--save {
+  min-width: 140px;
+  padding: 14px 32px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #2cb6c9, #1d8a9c);
+  box-shadow: 0 16px 40px rgba(20, 90, 103, 0.35);
+  font-size: 16px;
+}
+
+@media (max-width: 960px) {
+  .question-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.chapter-stage {
+  align-items: center;
+  padding: clamp(40px, 6vw, 72px) clamp(16px, 6vw, 48px);
+}
+
+.chapter-stage__container {
+  width: min(960px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(32px, 6vw, 48px);
+}
+
+.chapter-stage__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: linear-gradient(180deg, rgba(203, 223, 226, 0.85), rgba(171, 201, 206, 0.85));
+  border-radius: 18px;
+  padding: clamp(16px, 3vw, 24px) clamp(20px, 5vw, 32px);
+  box-shadow: 0 18px 40px rgba(5, 32, 40, 0.3);
+  backdrop-filter: blur(4px);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: #1f3f4b;
+}
+
+.chapter-stage__heading {
+  font-size: clamp(18px, 2.4vw, 22px);
+  font-weight: 600;
+}
+
+.chapter-stage__nav {
+  display: flex;
+  gap: clamp(12px, 3vw, 24px);
+}
+
+.chapter-stage__link {
+  text-decoration: none;
+  color: #20404c;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  box-shadow: 0 10px 24px rgba(15, 69, 82, 0.25);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.chapter-stage__link:hover,
+.chapter-stage__link:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 16px 28px rgba(15, 69, 82, 0.3);
+}
+
+.chapter-stage__link:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 3px;
+}
+
+.stage-card {
+  background: linear-gradient(180deg, rgba(219, 235, 246, 0.98), rgba(193, 218, 234, 0.96));
+  border-radius: clamp(26px, 6vw, 38px);
+  box-shadow: 0 32px 60px rgba(5, 32, 40, 0.45);
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  color: #26374a;
+  margin: 0 auto;
+}
+
+.stage-card--center {
+  width: min(520px, 90vw);
+}
+
+.stage-card__panel {
+  padding: clamp(32px, 6vw, 48px) clamp(28px, 6vw, 40px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(28px, 5vw, 36px);
+}
+
+.qr-display {
+  display: grid;
+  grid-template-columns: repeat(3, clamp(70px, 18vw, 96px));
+  gap: clamp(10px, 2.6vw, 16px);
+  background: rgba(30, 63, 76, 0.08);
+  padding: clamp(16px, 3vw, 22px);
+  border-radius: 24px;
+  box-shadow: inset 0 0 0 2px rgba(32, 64, 76, 0.15);
+}
+
+.qr-display__cell {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 12px;
+}
+
+.qr-display__cell--solid {
+  background: #2d3138;
+  box-shadow: inset 0 4px 6px rgba(0, 0, 0, 0.35);
+}
+
+.qr-display__cell--mini {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: clamp(4px, 1vw, 6px);
+  padding: clamp(6px, 1.2vw, 8px);
+  background: transparent;
+  box-shadow: inset 0 0 0 2px rgba(45, 49, 56, 0.18);
+}
+
+.qr-display__cell--mini span {
+  display: block;
+  background: #2d3138;
+  border-radius: 6px;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+.qr-display__dot--clear {
+  background: transparent;
+  box-shadow: none;
+}
+
+.qr-display__cell--clear {
+  background: transparent;
+  box-shadow: none;
+}
+
+.stage-card__cta {
+  border: none;
+  border-radius: 999px;
+  padding: 14px clamp(48px, 12vw, 72px);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: linear-gradient(180deg, #f9e7a0, #d4b66b);
+  color: #2a3b49;
+  box-shadow: 0 20px 40px rgba(61, 46, 7, 0.25);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.stage-card__cta:hover,
+.stage-card__cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 46px rgba(61, 46, 7, 0.3);
+}
+
+.stage-card__cta:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.75);
+  outline-offset: 4px;
+}
+
+.lobby-list {
+  width: 100%;
+  margin: 0;
+  padding: clamp(12px, 3vw, 18px) clamp(12px, 3vw, 24px);
+  list-style: none;
+  background: rgba(255, 255, 255, 0.55);
+  border-radius: clamp(20px, 5vw, 28px);
+  box-shadow: inset 0 0 0 2px rgba(31, 63, 76, 0.08);
+  font-size: 15px;
+  line-height: 1.8;
+  text-align: center;
+}
+
+.lobby-list li {
+  color: #2a3b49;
+  font-weight: 500;
+}
+
+@media (max-width: 640px) {
+  .builder-card {
+    padding: 24px;
+  }
+
+  .builder-card__title-input {
+    font-size: 20px;
+  }
+
+  .builder-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .builder-footer__group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .footer-field,
+  .footer-toggle {
+    justify-content: space-between;
+  }
+
+  .primary-button--save {
+    align-self: flex-end;
+  }
+
+  .chapter-stage__header {
+    flex-direction: column;
+    gap: 18px;
+    text-align: center;
+  }
+
+  .chapter-stage__nav {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .stage-card--center {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a chapter 1 QR check-in page with header navigation and gold CTA to mirror the provided mock
- add a chapter lobby page listing joined students and linking into the quiz flow
- extend shared styles and dashboard navigation triggers to support the new chapter stage layouts

## Testing
- manual QA


------
https://chatgpt.com/codex/tasks/task_e_68dc1d1a31ac83309d78374e7b453149